### PR TITLE
Add archive_file.output_file_mode to avoid drift state in different OS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,7 @@ data "aws_iam_policy_document" "pipeline_updates_policy" {
 data "archive_file" "notifier_package" {
   type        = "zip"
   source_file = "${path.module}/lambdas/notifier/notifier.py"
+  output_file_mode = "0666"
   output_path = "${path.module}/lambdas/notifier.zip"
 }
 


### PR DESCRIPTION
related discussion

https://github.com/hashicorp/terraform-provider-archive/issues/53